### PR TITLE
Update record dream

### DIFF
--- a/src/controller/dream_controller.rs
+++ b/src/controller/dream_controller.rs
@@ -9,13 +9,14 @@ use axum_session_auth::AuthSession;
 
 use crate::{
     data::{
-        dream_dto::NewDreamDto,
-        query_dto::{DateDto, DateRangeDto, LastDaysDto},
+        dream_dto::{NewDreamDto, UpdateDreamDto},
+        query_dto::{DateDto, DateRangeDto, IdDto, LastDaysDto},
     },
     model::session_model::CurrentUser,
     service::{
         dream_service::{
-            filter_dreams_by_date_service, get_all_dreams_from_baby_service, post_dream_service,
+            filter_dreams_by_date_service, get_all_dreams_from_baby_service, patch_dream_service,
+            post_dream_service,
         },
         dream_summary_service::{
             dream_summary_last_days_service, dream_summary_range_service, dream_summary_service,
@@ -27,7 +28,10 @@ use crate::{
 
 pub(super) fn route_dream() -> Router {
     Router::new()
-        .route("/:baby_id/dreams", get(get_dreams).post(post_dream))
+        .route(
+            "/:baby_id/dreams",
+            get(get_dreams).post(post_dream).patch(patch_dream),
+        )
         .route("/:baby_id/dreams/summary", get(dream_summary))
         .route("/:baby_id/dreams/summary/today", get(dream_summary_today))
         .route("/:baby_id/dreams/summary/last", get(dream_summary_last))
@@ -54,6 +58,16 @@ async fn post_dream(
 ) -> impl IntoResponse {
     authorize_and_has_baby(auth, baby_id)?;
     post_dream_service(new_dream, baby_id).await
+}
+
+async fn patch_dream(
+    Path(baby_id): Path<i32>,
+    auth: AuthSession<CurrentUser, i64, SessionRedisPool, redis::Client>,
+    record_id: Query<IdDto>,
+    Json(dream): Json<UpdateDreamDto>,
+) -> impl IntoResponse {
+    authorize_and_has_baby(auth, baby_id)?;
+    patch_dream_service(dream, record_id.id(), baby_id).await
 }
 
 async fn dream_summary(

--- a/src/controller/meal_controller.rs
+++ b/src/controller/meal_controller.rs
@@ -61,7 +61,7 @@ async fn patch_meal(
     Json(meal): Json<UpdateMealDto>,
 ) -> impl IntoResponse {
     authorize_and_has_baby(auth, baby_id)?;
-    patch_meal_service(meal, record_id.id()).await
+    patch_meal_service(meal, record_id.id(), baby_id).await
 }
 
 async fn meal_summary(

--- a/src/data/dream_dto.rs
+++ b/src/data/dream_dto.rs
@@ -24,3 +24,9 @@ pub struct DreamSummaryDto {
     pub date: String,
     pub summary: String
 }
+
+#[derive(Deserialize)]
+pub struct UpdateDreamDto {
+    pub from_date: Option<String>,
+    pub to_date: Option<String>
+}

--- a/src/model/dream_model.rs
+++ b/src/model/dream_model.rs
@@ -16,6 +16,24 @@ pub struct Dream {
 }
 
 impl Dream {
+    pub fn new(
+        id: i32,
+        baby_id: i32,
+        from_date: NaiveDateTime,
+        to_date: Option<NaiveDateTime>,
+    ) -> Self {
+        Self {
+            id,
+            baby_id,
+            from_date,
+            to_date,
+        }
+    }
+
+    pub fn baby_id(&self) -> i32 {
+        self.baby_id
+    }
+
     pub fn from_date(&self) -> NaiveDateTime {
         self.from_date
     }
@@ -42,11 +60,12 @@ impl Dream {
         }
     }
 
-    pub fn to_date(&self) -> NaiveDateTime {
-        match self.to_date {
-            Some(date) => date,
-            None => NaiveDateTime::default(),
-        }
+    pub fn to_date(&self) -> Option<NaiveDateTime> {
+        // match self.to_date {
+        //     Some(date) => date,
+        //     None => NaiveDateTime::default(),
+        // }
+        self.to_date
     }
 
     pub fn formatted_elapsed(&self) -> String {

--- a/src/repository/dream_repository.rs
+++ b/src/repository/dream_repository.rs
@@ -50,13 +50,23 @@ pub async fn update_last_dream(dream: InsertableDream) -> Result<usize, Error> {
 }
 
 pub async fn find_dreams_by_date(baby: i32, date: NaiveDate) -> Result<Vec<Dream>, Error> {
-    let timestamp = date.and_hms_opt(23, 59, 59).unwrap();
-    let last_dream_from_yesterday = find_last_dream_from_yesterday(baby, date).await;
     let conn = &mut establish_async_connection().await;
+    // let timestamp = date.and_hms_opt(23, 59, 59).unwrap();
+    // let last_dream_from_yesterday = find_last_dream_from_yesterday(baby, date).await;
+    // dreams::table
+    // dreams::table
+    //     .filter(dreams::baby_id.eq(baby))
+    //     .filter(dreams::to_date.lt(timestamp))
+    //     .filter(dreams::from_date.ge(last_dream_from_yesterday))
+    //     .load::<Dream>(conn)
+    //     .await
+    let down_time = date.and_hms_opt(0, 0, 1).unwrap();
+    let up_time = date.and_hms_opt(23, 59, 59).unwrap();
     dreams::table
         .filter(dreams::baby_id.eq(baby))
-        .filter(dreams::to_date.lt(timestamp))
-        .filter(dreams::from_date.ge(last_dream_from_yesterday))
+        .filter(dreams::from_date.ge(down_time))
+        .filter(dreams::from_date.le(up_time))
+        .order(dreams::from_date.asc())
         .load::<Dream>(conn)
         .await
 }
@@ -103,7 +113,7 @@ pub async fn find_first_record(baby: i32) -> Result<NaiveDate, Error> {
         .order(dreams::from_date.asc())
         .first::<Dream>(conn)
         .await?;
-    Ok(first_record.to_date().date())
+    Ok(first_record.to_date().unwrap().date())
 }
 
 pub async fn find_all_dreams_sorted(baby: i32) -> Result<Vec<Dream>, Error> {
@@ -113,5 +123,21 @@ pub async fn find_all_dreams_sorted(baby: i32) -> Result<Vec<Dream>, Error> {
         .filter(dreams::to_date.is_not_null())
         .order(dreams::to_date.asc())
         .load::<Dream>(conn)
+        .await
+}
+
+pub async fn find_dream_by_id(id: i32) -> Result<Dream, Error> {
+    let conn = &mut establish_async_connection().await;
+    dreams::table.find(id).first(conn).await
+}
+
+pub async fn patch_dream_record(dream: Dream) -> Result<usize, Error> {
+    let conn = &mut establish_async_connection().await;
+    diesel::update(dreams::table.find(dream.id()))
+        .set((
+            dreams::from_date.eq(dream.from_date()),
+            dreams::to_date.eq(dream.to_date()),
+        ))
+        .execute(conn)
         .await
 }

--- a/src/repository/meal_repository.rs
+++ b/src/repository/meal_repository.rs
@@ -44,6 +44,7 @@ pub async fn find_meals_by_date_range(
         .filter(meals::baby_id.eq(baby))
         .filter(meals::date.ge(from))
         .filter(meals::date.le(to))
+        .order(meals::date.asc())
         .load::<Meal>(conn)
         .await
 }
@@ -62,14 +63,14 @@ pub async fn find_meal_by_id(record: i32) -> Result<Meal, Error> {
     meals::table.find(record).first::<Meal>(conn).await
 }
 
-
 pub async fn patch_meal_record(meal: Meal) -> Result<usize, Error> {
     let conn = &mut establish_async_connection().await;
-    diesel::update(meals::table.filter(meals::id.eq(meal.id())))
-    .set((
-        meals::date.eq(meal.date()),
-        meals::quantity.eq(meal.quantity()),
-        meals::to_time.eq(meal.to_time()),
-    ))
-    .execute(conn).await
+    diesel::update(meals::table.find(meal.id()))
+        .set((
+            meals::date.eq(meal.date()),
+            meals::quantity.eq(meal.quantity()),
+            meals::to_time.eq(meal.to_time()),
+        ))
+        .execute(conn)
+        .await
 }

--- a/src/service/dream_summary_service.rs
+++ b/src/service/dream_summary_service.rs
@@ -6,7 +6,7 @@ use crate::{
     error::error::ApiError,
     model::{dream_model::Dream, summary_model::DreamSummary},
     repository::dream_repository::{find_all_dreams_sorted, find_dreams_summary},
-    utils::datetime::{iter_between_two_dates, today},
+    utils::datetime::{iter_between_two_dates, today, now},
 };
 
 use super::util_service::{check_days_out_of_bounds, dates_are_in_order};
@@ -55,7 +55,7 @@ async fn fetch_dream_summary_range(
         let partial_dreams = dreams
             .clone()
             .into_iter()
-            .filter(|dream| dream.to_date().date().eq(&day))
+            .filter(|dream| dream.to_date().unwrap_or(now()).date().eq(&day))
             .collect::<Vec<Dream>>();
         if !partial_dreams.is_empty() {
             let summary = DreamSummary::new(day, partial_dreams);
@@ -96,7 +96,7 @@ pub async fn get_all_dream_summaries_service(
     let mut summaries: Vec<DreamSummary> = Vec::new();
     let all_records = find_all_dreams_sorted(baby_id).await?;
     let initial_record = match all_records.first() {
-        Some(initial) => initial.to_date().date(),
+        Some(initial) => initial.to_date().unwrap().date(),
         None => return Ok(into_json_summary(summaries)),
     };
     let today = today().checked_add_days(Days::new(1)).unwrap();
@@ -105,7 +105,7 @@ pub async fn get_all_dream_summaries_service(
         let partial_dreams = all_records
             .clone()
             .into_iter()
-            .filter(|dream| dream.to_date().date().eq(&day))
+            .filter(|dream| dream.to_date().unwrap().date().eq(&day))
             .collect::<Vec<Dream>>();
         if !partial_dreams.is_empty() {
             let summary = DreamSummary::new(day, partial_dreams);

--- a/src/service/meal_service.rs
+++ b/src/service/meal_service.rs
@@ -30,8 +30,11 @@ pub async fn post_meal_service(new_meal: NewMealDto, baby_id: i32) -> Result<Res
     Ok(Response::NewRecord)
 }
 
-pub async fn patch_meal_service(meal: UpdateMealDto, record: i32) -> Result<Response, ApiError> {
+pub async fn patch_meal_service(meal: UpdateMealDto, record: i32, baby_id: i32) -> Result<Response, ApiError> {
     let old_meal = find_meal_by_id(record).await?;
+    if baby_id.ne(&old_meal.baby_id()) {
+        return Err(ApiError::Forbidden)
+    }
     let new_date = match meal.date {
         Some(v) => convert_to_date_time(&v)?,
         None => old_meal.date(),

--- a/src/service/util_service.rs
+++ b/src/service/util_service.rs
@@ -1,11 +1,9 @@
 use chrono::{NaiveDate, NaiveDateTime};
-use hyper::StatusCode;
 
 use crate::{
     error::error::ApiError,
-    utils::{
-        datetime::{date_is_lower_than_other_date, convert_to_date_time, date_time_is_lower_than_other_date},
-        response::Response,
+    utils::datetime::{
+        convert_to_date_time, date_is_lower_than_other_date, date_time_is_lower_than_other_date,
     },
 };
 


### PR DESCRIPTION
- Update records in dream service.
- Find dreams by date recover dreams that start and ends in that day, not from the day before.
- Add check before updating records.