### PR TITLE
Share baby reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,11 +301,13 @@ data:
 
 ### Baby: `/api/baby`
 
-| Route     | Method   | Function                                     | Parameters              | Arguments         |
-| --------- | -------- | -------------------------------------------- | ----------------------- | ----------------- |
-| /new      | `post`   | Add new baby                                 | Body: Json              | {name, birthdate} |
-| /:baby_id | `patch`  | Update baby info by id                       | Path: i32 \| Body: Json | {name, birthdate} |
-| /:baby_id | `delete` | Delete baby and all records associated to it | Path: i32               |                   |
+| Route                             | Method   | Function                                     | Parameters                    | Arguments         |
+| --------------------------------- | -------- | -------------------------------------------- | ----------------------------- | ----------------- |
+| /                                 | `get`    | Get all babies for current user              |                               |                   |
+| /                                 | `post`   | Add new baby                                 | Body: Json                    | {name, birthdate} |
+| /:baby_id                         | `patch`  | Update baby info by id                       | Path: i32 \| Body: Json       | {name, birthdate} |
+| /:baby_id                         | `delete` | Delete baby and all records associated to it | Path: i32                     |                   |
+| /:baby_id/share?username=username | `post`   | Associate current baby to another username   | Path: i32 \| username: String |                   |
 
 ### Meals: `/api/baby/:baby_id`
 

--- a/src/controller/baby_controller.rs
+++ b/src/controller/baby_controller.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::Path,
+    extract::{Path, Query},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
@@ -8,11 +8,16 @@ use axum_session::SessionRedisPool;
 use axum_session_auth::AuthSession;
 
 use crate::{
-    data::baby_dto::InputBabyDto,
+    data::{
+        baby_dto::InputBabyDto,
+        query_dto::{Pagination, Username},
+    },
     model::session_model::CurrentUser,
     service::{
+        association_service::add_baby_to_user_service,
         baby_service::{
-            delete_baby_service, find_baby_service, ingest_new_baby, patch_baby_service,
+            delete_baby_service, find_baby_service, ingest_new_baby, load_babies_for_current_user,
+            patch_baby_service,
         },
         session_service::{authorize_and_has_baby, login_required, update_user_session},
     },
@@ -24,11 +29,12 @@ use super::{
 
 pub(crate) fn route_baby() -> Router {
     let routes: Router = Router::new()
-        .route("/new", post(register_baby))
+        .route("/", get(get_babies_for_user).post(register_baby))
         .route(
             "/:baby_id",
             get(find_baby_by_id).patch(patch_baby).delete(delete_baby),
         )
+        .route("/:baby_id/share", post(share_ownership))
         .merge(route_meal())
         .merge(route_dream())
         .merge(route_weight());
@@ -43,7 +49,7 @@ async fn register_baby(
     login_required(auth.clone())?;
     match ingest_new_baby(new_baby, id).await {
         Ok(baby) => {
-            update_user_session(&auth.current_user.unwrap()).await?;
+            update_user_session(auth).await?;
             Ok(baby)
         }
         Err(error) => Err(error),
@@ -71,6 +77,28 @@ async fn delete_baby(
     Path(baby_id): Path<i32>,
     auth: AuthSession<CurrentUser, i64, SessionRedisPool, redis::Client>,
 ) -> impl IntoResponse {
+    authorize_and_has_baby(auth.clone(), baby_id)?;
+    let message = delete_baby_service(baby_id).await;
+    update_user_session(auth).await?;
+    message
+}
+
+async fn get_babies_for_user(
+    auth: AuthSession<CurrentUser, i64, SessionRedisPool, redis::Client>,
+    page: Option<Query<Pagination>>,
+) -> impl IntoResponse {
+    let id: i64 = auth.id;
+    let pagination = page.unwrap_or_default().0;
+    login_required(auth)?;
+    load_babies_for_current_user(id, pagination).await
+}
+
+async fn share_ownership(
+    Path(baby_id): Path<i32>,
+    auth: AuthSession<CurrentUser, i64, SessionRedisPool, redis::Client>,
+    user: Query<Username>,
+) -> impl IntoResponse {
     authorize_and_has_baby(auth, baby_id)?;
-    delete_baby_service(baby_id).await
+    let username = user.username()?;
+    add_baby_to_user_service(baby_id, &username).await
 }

--- a/src/data/query_dto.rs
+++ b/src/data/query_dto.rs
@@ -119,12 +119,15 @@ fn parse_date(date: &str) -> Result<NaiveDate, ApiError> {
 
 #[derive(Deserialize)]
 pub struct Username {
-    value: Option<String>,
+    username: Option<String>,
 }
 
 impl Username {
-    pub fn value(&self) -> Option<String> {
-        self.value.to_owned()
+    pub fn username(&self) -> Result<String, ApiError> {
+        match self.username.to_owned() {
+            Some(value) => Ok(value),
+            None => Err(ApiError::EmptyBody),
+        }
     }
 }
 

--- a/src/repository/association_repository.rs
+++ b/src/repository/association_repository.rs
@@ -10,9 +10,17 @@ use super::connection_psql::establish_connection;
 
 pub fn add_rol_to_user(user: i32, rol: i16) -> Result<usize, Error> {
     let conn = &mut establish_connection();
-    diesel::insert_into(users_roles::table)
-        .values((&rol_id.eq(rol), &users_roles::user_id.eq(user)))
-        .execute(conn)
+    let records: i64 = users_roles::table
+        .filter(users_roles::rol_id.eq(rol))
+        .filter(users_roles::user_id.eq(user))
+        .count()
+        .get_result(conn)?;
+    match records {
+        0 => diesel::insert_into(users_roles::table)
+            .values((&rol_id.eq(rol), &users_roles::user_id.eq(user)))
+            .execute(conn),
+        _ => Ok(1),
+    }
 }
 
 /// Look if there is an already association, if there is, return 1, else create a new association.

--- a/src/repository/association_repository.rs
+++ b/src/repository/association_repository.rs
@@ -15,9 +15,18 @@ pub fn add_rol_to_user(user: i32, rol: i16) -> Result<usize, Error> {
         .execute(conn)
 }
 
+/// Look if there is an already association, if there is, return 1, else create a new association.
 pub fn add_baby_to_user(user: i32, baby: i32) -> Result<usize, Error> {
     let conn = &mut establish_connection();
-    diesel::insert_into(users_babies::table)
-        .values((&baby_id.eq(baby), &users_babies::user_id.eq(user)))
-        .execute(conn)
+    let records: i64 = users_babies::table
+        .filter(users_babies::baby_id.eq(baby))
+        .filter(users_babies::user_id.eq(user))
+        .count()
+        .get_result(conn)?;
+    match records {
+        0 => diesel::insert_into(users_babies::table)
+            .values((&baby_id.eq(baby), &users_babies::user_id.eq(user)))
+            .execute(conn),
+        _ => Ok(1),
+    }
 }

--- a/src/repository/baby_repository.rs
+++ b/src/repository/baby_repository.rs
@@ -4,22 +4,33 @@ use diesel::result::Error;
 use crate::{
     data::{baby_dto::UpdateBaby, query_dto::Pagination},
     model::baby_model::{Baby, InsertableBaby},
-    schema::babies,
+    schema::{babies, users_babies},
 };
 
 use super::{connection_psql::establish_connection, paginator::Paginate};
 
-pub fn ingest_new_baby_in_db<T>(new_baby: T) -> Result<Baby, Error>
+pub fn ingest_new_baby_in_db<T>(new_baby: T, user: i32) -> Result<Baby, Error>
 where
     T: Into<InsertableBaby>,
 {
     let conn = &mut establish_connection();
-    diesel::insert_into(babies::table)
+    // Create baby entry in db.
+    let baby = diesel::insert_into(babies::table)
         .values(new_baby.into())
         .returning(Baby::as_returning())
-        .get_result(conn)
-
-    // .execute(conn)
+        .get_result(conn);
+    let binding = match baby {
+        Ok(ref value) => value.id(),
+        Err(e) => return Err(e),
+    };
+    // Associate baby and user.
+    diesel::insert_into(users_babies::table)
+        .values((
+            &users_babies::baby_id.eq(binding),
+            &users_babies::user_id.eq(user),
+        ))
+        .execute(conn)?;
+    baby
 }
 
 pub fn load_baby_by_id(id: i32) -> Result<Baby, Error> {
@@ -49,4 +60,16 @@ pub fn patch_baby_record(baby: i32, update: UpdateBaby) -> Result<usize, Error> 
 pub fn delete_baby_from_db(baby: i32) -> Result<usize, Error> {
     let conn = &mut establish_connection();
     diesel::delete(babies::table.find(baby)).execute(conn)
+}
+
+pub fn get_all_babies_with_id(
+    babies: Vec<i32>,
+    pagination: Pagination,
+) -> Result<(Vec<Baby>, u32), Error> {
+    let conn = &mut establish_connection();
+    babies::table
+        .filter(babies::id.eq_any(babies))
+        .paginate(pagination.page())
+        .per_page(pagination.per_page())
+        .load_and_count_pages(conn)
 }

--- a/src/repository/user_repository.rs
+++ b/src/repository/user_repository.rs
@@ -65,12 +65,18 @@ pub fn find_roles_id(user_id: i32) -> Result<HashSet<u8>, Error> {
     Ok(roles)
 }
 
-pub fn find_babies_id(user_id: i32) -> Result<Vec<i32>, Error> {
+pub fn find_babies_id(user_id: i32) -> Result<HashSet<i32>, Error> {
+    let mut babies: HashSet<i32> = HashSet::new();
     let conn = &mut establish_connection();
     users_babies::table
         .filter(users_babies::user_id.eq(user_id))
         .select(users_babies::baby_id)
-        .load::<i32>(conn)
+        .load::<i32>(conn)?
+        .into_iter()
+        .for_each(|id| {
+            babies.insert(id);
+        });
+    Ok(babies)
 }
 
 pub fn patch_user_record(user_id: i32, profile: UpdateUser) -> Result<usize, Error> {

--- a/src/service/association_service.rs
+++ b/src/service/association_service.rs
@@ -2,7 +2,10 @@ use crate::{
     error::error::ApiError,
     model::role_model::Rol,
     repository::association_repository::{add_baby_to_user, add_rol_to_user},
+    utils::response::Response,
 };
+
+use super::user_service::find_user_by_username_service;
 
 pub async fn add_rol_to_user_service<T>(user_id: T, rol: Rol) -> Result<(), ApiError>
 where
@@ -12,10 +15,10 @@ where
     Ok(())
 }
 
-pub async fn add_baby_to_user_service<T>(user_id: T, baby_id: T) -> Result<(), ApiError>
-where
-    T: Into<i32>,
-{
-    add_baby_to_user(user_id.into(), baby_id.into())?;
-    Ok(())
+pub async fn add_baby_to_user_service(baby_id: i32, username: &str) -> Result<Response, ApiError> {
+    let user = find_user_by_username_service(username).await?;
+    match add_baby_to_user(user.id(), baby_id) {
+        Ok(_) => Ok(Response::UpdateRecord),
+        Err(error) => Err(ApiError::DBError(error)),
+    }
 }

--- a/src/service/user_service.rs
+++ b/src/service/user_service.rs
@@ -89,8 +89,11 @@ pub async fn find_user_by_id_service(user_id: i32) -> Result<Json<UserDto>, ApiE
     Ok(Json(user.into()))
 }
 
-pub async fn find_user_by_username_service(username: &String) -> Result<User, ApiError> {
-    Ok(load_user_by_username(username)?)
+pub async fn find_user_by_username_service(username: &str) -> Result<User, ApiError> {
+    match load_user_by_username(username) {
+        Ok(user) => Ok(user),
+        Err(_) => Err(ApiError::NoUser),
+    }
 }
 
 


### PR DESCRIPTION
- Share baby reference with other users.
- Get babies associated to current user.
- Change path to baby.
- Clear cache on update user.
- Optimize query call after adding a baby or a new user.
- Avoid duplicates on associations.
- Use a HashSet instead of Vec for babies, no more duplicates.