### PR TITLE
Read roles from database

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nighty_night"
-version = "0.4.1"
+version = "0.4.2"
 authors = ["Jaime Alvarez <jaime.af.git@gmail.com>"]
 description = "Backend written with Axum framework and diesel as ORM. It records feeding and sleeping patterns in newborns and, additionally, it allows to record the baby's weight. Session is stored in redis."
 readme = "README.md"

--- a/src/controller/admin_controller.rs
+++ b/src/controller/admin_controller.rs
@@ -16,7 +16,7 @@ use crate::{
         user_service::{
             delete_active_user_service, delete_old_users_service, delete_user_service,
             get_all_users_service,
-        },
+        }, role_service::get_role_by_name_service,
     },
 };
 
@@ -107,7 +107,8 @@ async fn put_user_role(
     Json(user_role): Json<UpdateRole>,
 ) -> impl IntoResponse {
     current_user_is_admin(auth)?;
-    add_rol_to_user_service(&user_role.username, user_role.role.into()).await
+    let rol = get_role_by_name_service(&user_role.role).await?;
+    add_rol_to_user_service(&user_role.username, rol).await
 }
 
 async fn delete_user_role(
@@ -115,5 +116,6 @@ async fn delete_user_role(
     Json(user_role): Json<UpdateRole>,
 ) -> impl IntoResponse {
     current_user_is_admin(auth)?;
-    delete_rol_to_user_service(&user_role.username, user_role.role.into()).await
+    let rol = get_role_by_name_service(&user_role.role).await?;
+    delete_rol_to_user_service(&user_role.username, rol).await
 }

--- a/src/data/session_dto.rs
+++ b/src/data/session_dto.rs
@@ -11,7 +11,7 @@ pub struct CurrentUserDto {
     pub id: i64,
     pub anonymous: bool,
     pub username: String,
-    pub roles: Vec<u8>,
+    pub roles: Vec<i16>,
     pub active: bool,
     pub baby_id: Vec<BabyInfo>,
 }
@@ -21,7 +21,7 @@ impl CurrentUserDto {
         id: i64,
         anonymous: bool,
         username: String,
-        roles: Vec<u8>,
+        roles: Vec<i16>,
         active: bool,
         baby_id: Vec<BabyInfo>,
     ) -> Self {

--- a/src/mapping/rol_mapper.rs
+++ b/src/mapping/rol_mapper.rs
@@ -3,27 +3,16 @@ use crate::{
         common_structure::{BasicDataStruct, DataType},
         role_dto::RoleData,
     },
-    model::role_model::{Rol, Role},
+    model::role_model::Rol,
     repository::admin_repository::GroupedRole,
 };
 
-pub fn translate_roles(roles: &[u8]) -> Vec<Rol> {
+pub fn translate_roles(roles: &[i16]) -> Vec<Rol> {
     roles.into_iter().map(|id| (*id).into()).collect()
 }
 
-impl From<Role> for Rol {
-    fn from(value: Role) -> Self {
-        match value.id() {
-            0 => Rol::Admin,
-            1 => Rol::User,
-            2 => Rol::Anonymous,
-            _ => Rol::Anonymous,
-        }
-    }
-}
-
-impl From<u8> for Rol {
-    fn from(value: u8) -> Self {
+impl From<i16> for Rol {
+    fn from(value: i16) -> Self {
         match value {
             0 => Rol::Admin,
             1 => Rol::User,
@@ -43,16 +32,6 @@ impl From<Rol> for i16 {
     }
 }
 
-impl From<Rol> for u8 {
-    fn from(rol: Rol) -> Self {
-        match rol {
-            Rol::Anonymous => 2,
-            Rol::User => 1,
-            Rol::Admin => 0,
-        }
-    }
-}
-
 impl From<GroupedRole> for BasicDataStruct<RoleData> {
     fn from(value: GroupedRole) -> Self {
         let attributes = RoleData {
@@ -60,25 +39,5 @@ impl From<GroupedRole> for BasicDataStruct<RoleData> {
             count: value.count,
         };
         BasicDataStruct::new(value.id.into(), DataType::Role, attributes)
-    }
-}
-
-impl From<Rol> for String {
-    fn from(value: Rol) -> Self {
-        match value {
-            Rol::Anonymous => "anonymous".to_string(),
-            Rol::User => "user".to_string(),
-            Rol::Admin => "admin".to_string(),
-        }
-    }
-}
-
-impl From<String> for Rol {
-    fn from(value: String) -> Self {
-        match value.to_lowercase().as_str() {
-            "anonymous" => Rol::Anonymous,
-            "admin" => Rol::Admin,
-            _ => Rol::User,
-        }
     }
 }

--- a/src/model/session_model.rs
+++ b/src/model/session_model.rs
@@ -76,7 +76,7 @@ impl CurrentUser {
             .collect()
     }
 
-    pub fn roles_id(&self) -> Vec<u8> {
+    pub fn roles_id(&self) -> Vec<i16> {
         self.roles
             .to_owned()
             .into_iter()

--- a/src/model/user_model.rs
+++ b/src/model/user_model.rs
@@ -2,7 +2,7 @@ use chrono::NaiveDateTime;
 use diesel::prelude::*;
 
 use crate::{
-    data::user_dto::UpdateUserDto, repository::user_repository::select_roles_id_from_user,
+    data::user_dto::UpdateUserDto, repository::role_repository::select_roles_names_from_user,
     schema::users, security::security::verify_password, utils::datetime::now,
 };
 
@@ -82,16 +82,8 @@ impl User {
     }
 
     pub fn roles(&self) -> Vec<String> {
-        let roles = select_roles_id_from_user(self.id).unwrap();
+        let roles = select_roles_names_from_user(self.id).unwrap();
         roles
-            .into_iter()
-            .map(|rol| match rol {
-                0 => "admin".to_string(),
-                1 => "user".to_string(),
-                2 => "anonymous".to_string(),
-                _ => "undefined".to_string(),
-            })
-            .collect()
     }
 
     pub fn update_profile(&self, profile: UpdateUserDto) -> Self {

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -7,3 +7,4 @@ pub mod paginator;
 pub mod session_repository;
 pub mod user_repository;
 pub mod weight_repository;
+pub mod role_repository;

--- a/src/repository/role_repository.rs
+++ b/src/repository/role_repository.rs
@@ -1,0 +1,44 @@
+use std::collections::HashSet;
+
+use diesel::prelude::*;
+use diesel::result::Error;
+
+use crate::{
+    connection::connection_psql::establish_connection,
+    model::role_model::Role,
+    schema::{roles, users_roles},
+};
+
+pub fn select_roles_names_from_user(user_id: i32) -> Result<Vec<String>, Error> {
+    let conn = &mut establish_connection();
+    let roles_id: Vec<i16> = users_roles::table
+        .filter(users_roles::user_id.eq(user_id))
+        .select(users_roles::rol_id)
+        .load::<i16>(conn)?;
+    let role_alias: Result<Vec<String>, Error> = roles::table
+        .filter(roles::id.eq_any(roles_id))
+        .select(roles::name)
+        .load::<String>(conn);
+    role_alias
+}
+
+pub fn select_roles_id_from_user(user_id: i32) -> Result<HashSet<i16>, Error> {
+    let mut roles: HashSet<i16> = HashSet::new();
+    let conn = &mut establish_connection();
+    users_roles::table
+        .filter(users_roles::user_id.eq(user_id))
+        .select(users_roles::rol_id)
+        .load::<i16>(conn)?
+        .iter()
+        .for_each(|id| {
+            roles.insert((*id).try_into().unwrap());
+        });
+    Ok(roles)
+}
+
+pub fn select_role_from_role_name(rol_name: &str) -> Result<Role, Error> {
+    let conn = &mut establish_connection();
+    roles::table
+        .filter(roles::name.eq(rol_name))
+        .get_result(conn)
+}

--- a/src/repository/user_repository.rs
+++ b/src/repository/user_repository.rs
@@ -1,5 +1,3 @@
-use std::collections::HashSet;
-
 use crate::{
     data::query_dto::Pagination,
     model::{
@@ -63,20 +61,6 @@ pub fn insert_new_user<T: Into<InsertableUser>>(new_user: T, rol: i16) -> Result
         ))
         .execute(conn)?;
     user
-}
-
-pub fn select_roles_id_from_user(user_id: i32) -> Result<HashSet<u8>, Error> {
-    let mut roles: HashSet<u8> = HashSet::new();
-    let conn = &mut establish_connection();
-    users_roles::table
-        .filter(users_roles::user_id.eq(user_id))
-        .select(users_roles::rol_id)
-        .load::<i16>(conn)?
-        .iter()
-        .for_each(|id| {
-            roles.insert((*id).try_into().unwrap());
-        });
-    Ok(roles)
 }
 
 pub fn update_user(profile: User) -> Result<User, Error> {

--- a/src/service/mod.rs
+++ b/src/service/mod.rs
@@ -9,3 +9,4 @@ pub mod user_service;
 pub mod util_service;
 pub mod weight_service;
 pub mod admin_service;
+pub mod role_service;

--- a/src/service/role_service.rs
+++ b/src/service/role_service.rs
@@ -1,0 +1,30 @@
+use crate::{
+    model::role_model::Rol, repository::role_repository::select_role_from_role_name,
+    response::error::ApiError,
+};
+
+pub async fn get_role_by_name_service(rol_name: &str) -> Result<Rol, ApiError> {
+    let normalized_str = rol_name.to_lowercase();
+    let role_model = select_role_from_role_name(&normalized_str)?;
+    let rol: Rol = role_model.id().into();
+    Ok(rol)
+}
+
+#[cfg(test)]
+mod test_role_service {
+    use std::path::Path;
+
+    use super::*;
+
+    fn load_env() {
+        dotenvy::from_path(Path::new("./key/local.env")).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_role_name() {
+        load_env();
+        assert_eq!(get_role_by_name_service("admin").await.unwrap(), Rol::Admin);
+        assert_eq!(get_role_by_name_service("AdMin").await.unwrap(), Rol::Admin);
+        assert!(get_role_by_name_service("invent").await.is_err());
+    }
+}

--- a/src/service/session_service.rs
+++ b/src/service/session_service.rs
@@ -14,8 +14,8 @@ use crate::{
             select_user_session, select_user_session_exists,
         },
         user_repository::{
-            select_babies_for_user_id, select_roles_id_from_user, select_user_by_id,
-        },
+            select_babies_for_user_id, select_user_by_id,
+        }, role_repository::select_roles_id_from_user,
     },
     response::{error::ApiError, response::RecordResponse},
 };
@@ -95,7 +95,7 @@ pub async fn read_user_from_db(user: i32) -> Result<CurrentUser, ApiError> {
 pub async fn create_current_user(current_user: User) -> Result<CurrentUser, ApiError> {
     let roles = select_roles_id_from_user(current_user.id())?;
     let babies = select_babies_for_user_id(current_user.id())?;
-    let translate_roles: Vec<Rol> = translate_roles(&roles.into_iter().collect::<Vec<u8>>());
+    let translate_roles: Vec<Rol> = translate_roles(&roles.into_iter().collect::<Vec<i16>>());
 
     let user_session = CurrentUser::new(
         current_user.id().into(),


### PR DESCRIPTION
Instead of hard-coding all possible values for roles, read names
and ids from existing database. There needs to be a conversion
from Role class to Rol enum, since it's easier to work with a
closed list.
