### PR TITLE
Split app methods

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nighty_night"
-version = "0.4.8"
+version = "0.4.9"
 authors = ["Jaime Alvarez <jaime.af.git@gmail.com>"]
 description = "Backend written with Axum framework and diesel as ORM. It records feeding and sleeping patterns in newborns and, additionally, it allows to record the baby's weight. Session is stored in redis."
 readme = "README.md"

--- a/src/app.rs
+++ b/src/app.rs
@@ -4,21 +4,63 @@ use axum_session::{SessionLayer, SessionRedisPool, SessionStore};
 use axum_session_auth::AuthSessionLayer;
 use controller::{baby_controller::route_baby, user_controller::route_user};
 use hyper::Request;
+use redis::Client;
 use tower_http::trace::TraceLayer;
 use tracing::{error, info_span};
 
 use crate::{
-    configuration::{settings::Setting, app_settings::{session_config, private_cookies_session, auth_config}},
+    configuration::{
+        app_settings::{auth_config, private_cookies_session, session_config},
+        settings::Setting,
+    },
+    connection::connection_redis::poll,
     controller::{self, admin_controller::route_admin},
     model::session_model::CurrentUser,
-    utils::{app::error_404, logger::setup_logger}, connection::connection_redis::poll,
+    utils::app::error_404,
 };
 
 /// Create app object with routes and layers.
 /// Session layer must be on top of session auth layer.
-pub async fn create_app_route() -> Router {
-    setup_logger();
+pub fn create_router() -> Router {
+    Router::new().nest(
+        "/api",
+        Router::new()
+            .merge(route_user())
+            .merge(route_baby())
+            .merge(route_admin()),
+    )
+}
 
+pub async fn expand_router_layer(app: Router) -> Router {
+    let (poll, session_store) = create_session_store().await;
+
+    // Add layer services
+    app.layer(
+        TraceLayer::new_for_http().make_span_with(|request: &Request<_>| {
+            // Log the matched route's path (with placeholders not filled in).
+            // Use request.uri() or OriginalUri if you want the real path.
+            let matched_path = request
+                .extensions()
+                .get::<MatchedPath>()
+                .map(MatchedPath::as_str);
+
+            info_span!(
+                "http_request",
+                method = ?request.method(),
+                matched_path,
+                some_other_field = tracing::field::Empty,
+            )
+        }),
+    )
+    .layer(
+        AuthSessionLayer::<CurrentUser, i64, SessionRedisPool, redis::Client>::new(Some(poll))
+            .with_config(auth_config()),
+    )
+    .layer(SessionLayer::new(session_store))
+    .fallback(error_404)
+}
+
+async fn create_session_store() -> (Client, SessionStore<SessionRedisPool>) {
     let config = if Setting::Branch.get().eq("local") {
         session_config()
     } else {
@@ -32,37 +74,5 @@ pub async fn create_app_route() -> Router {
         Ok(_) => (),
         Err(error) => error!("{error}"),
     };
-
-    let app = Router::new()
-        .nest(
-            "/api",
-            Router::new()
-                .merge(route_user())
-                .merge(route_baby())
-                .merge(route_admin()),
-        )
-        .layer(
-            TraceLayer::new_for_http().make_span_with(|request: &Request<_>| {
-                // Log the matched route's path (with placeholders not filled in).
-                // Use request.uri() or OriginalUri if you want the real path.
-                let matched_path = request
-                    .extensions()
-                    .get::<MatchedPath>()
-                    .map(MatchedPath::as_str);
-
-                info_span!(
-                    "http_request",
-                    method = ?request.method(),
-                    matched_path,
-                    some_other_field = tracing::field::Empty,
-                )
-            }),
-        )
-        .layer(
-            AuthSessionLayer::<CurrentUser, i64, SessionRedisPool, redis::Client>::new(Some(poll))
-                .with_config(auth_config()),
-        )
-        .layer(SessionLayer::new(session_store))
-        .fallback(error_404);
-    app
+    (poll, session_store)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use app::create_app_route;
 use std::path::Path;
 use tracing::info;
 
 use crate::{
+    app::{expand_router_layer, create_router},
     configuration::settings::Setting,
     utils::app::{checking_status, set_anonymous_user, shutdown_signal},
 };
@@ -33,7 +33,7 @@ pub mod response;
 mod schema;
 mod security;
 pub mod service;
-mod utils;
+pub mod utils;
 
 /// Prepare environment variables.
 ///
@@ -62,8 +62,9 @@ pub async fn check_db_initialisation() {
 }
 
 /// Launch server
-pub async fn create_app() {
-    let app = create_app_route().await;
+pub async fn serve_app() {
+    let router = create_router();
+    let app = expand_router_layer(router).await;
 
     info!("Branch mode: {}", Setting::Branch.get());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,11 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use nighty_night::{check_db_initialisation, create_app, set_environment};
+use nighty_night::{check_db_initialisation, serve_app, set_environment, utils::logger::setup_logger};
 
 #[tokio::main]
 async fn main() {
     set_environment();
+    setup_logger();
     check_db_initialisation().await;
-    create_app().await
+    serve_app().await
 }

--- a/tests/test_endpoints.rs
+++ b/tests/test_endpoints.rs
@@ -2,7 +2,7 @@ pub mod common;
 
 use axum::http::StatusCode;
 use axum_test_helper::{TestClient, TestResponse};
-use nighty_night::app::create_app_route;
+use nighty_night::app::{expand_router_layer, create_router};
 use serde_json::{json, Value};
 
 const SESSION: &'static str = "/api/auth/session";
@@ -34,7 +34,7 @@ fn init() {
 
 #[tokio::test]
 async fn test_anonymous_call() {
-    let router = create_app_route().await;
+    let router = expand_router_layer(create_router()).await;
     let client = TestClient::new(router);
 
     let welcome_test = client.get(SESSION).send().await;


### PR DESCRIPTION
No changes in functionality. Split create_app_router so it's more
convenient to add new functionalities or expand layers.
Setup logger before serving the app, avoiding multiples logger
creation.
