### PR TITLE
Flexible docker ports

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update \
     && apt-get install -y ca-certificates libpq5 \
     && rm -rf /var/lib/apt/lists/*
 
-EXPOSE 3000
+ENV PORT=3000
+EXPOSE ${PORT}
 
 ENV APP_USER=appuser
 

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -13,7 +13,7 @@ services:
   postgres:
     image: postgres:14.9
     ports:
-      - '8080:5432'
+      - '${POSTGRES_PORT}:5432'
     restart: unless-stopped
     environment:
       - POSTGRES_USER
@@ -29,7 +29,7 @@ services:
     image: redis:7.2
     restart: unless-stopped
     ports:
-      - '8081:6379'
+      - '${REDIS_PORT}:6379'
     command: redis-server --loglevel warning
     volumes: 
       - redis:/data
@@ -38,7 +38,7 @@ services:
   backend:
     image: 'nighty_night:latest'
     ports:
-      - '3000:3000'
+      - '${PORT}:${PORT}'
     environment:
       - BRANCH
       - POSTGRES_PASSWORD


### PR DESCRIPTION
I was having bad integrations with other apps and exposed ports.
Setting those ports as an .env variable, make changes flexible and
let the users decide in which available port run the server.
